### PR TITLE
Removes validate differences when comparing an Oracle Database Schema against a Spring Jpa / HibernateDatabase, fixes #718

### DIFF
--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedForeignKeyChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedForeignKeyChangeGenerator.java
@@ -28,6 +28,7 @@ public class ChangedForeignKeyChangeGenerator extends liquibase.diff.output.chan
         if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
             differences.removeDifference("deleteRule");
             differences.removeDifference("updateRule");
+            differences.removeDifference("validate");
             if (!differences.hasDifferences()) {
                 return null;
             }

--- a/src/main/java/liquibase/ext/hibernate/diff/ChangedPrimaryKeyChangeGenerator.java
+++ b/src/main/java/liquibase/ext/hibernate/diff/ChangedPrimaryKeyChangeGenerator.java
@@ -27,6 +27,7 @@ public class ChangedPrimaryKeyChangeGenerator extends liquibase.diff.output.chan
     public Change[] fixChanged(DatabaseObject changedObject, ObjectDifferences differences, DiffOutputControl control, Database referenceDatabase, Database comparisonDatabase, ChangeGeneratorChain chain) {
         if (referenceDatabase instanceof HibernateDatabase || comparisonDatabase instanceof HibernateDatabase) {
             differences.removeDifference("unique");
+            differences.removeDifference("validate");
             if (!differences.hasDifferences()) {
                 return null;
             }


### PR DESCRIPTION
https://github.com/liquibase/liquibase-hibernate/pull/719#issue-2538162080